### PR TITLE
Fixed and improved pages loading

### DIFF
--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -36,8 +36,7 @@ function App({ Component, pageProps = { title: 'index' } }) {
       <Header title={pageProps.title} />
       <Transition>
         <Dom classes={isColored}>
-          {/* <Dom className={`${pageProps.title == 'Buy' ? 'colored-background' : null}`}> */}
-          {Component && progress >= 100 ? <Component {...pageProps} /> : null}
+          {Component && <Component {...pageProps} />}
         </Dom>
       </Transition>
       {Component?.r3f && (


### PR DESCRIPTION
Pages other than the homepage (like /about) couldn't be directly loaded, by typing their URL.

The app was waiting for the 3D island to be fully loaded before displaying the site template. It's not needed anymore. Disabling this feature allows for an (almost) instantaneous loading of the site, allowing the user to immediately use navigation, for instance.