### PR TITLE
Add a back to top button

### DIFF
--- a/src/components/layout/dom.tsx
+++ b/src/components/layout/dom.tsx
@@ -1,13 +1,16 @@
 import { setState } from '@/helpers/store'
 import { useEffect, useRef } from 'react'
 
-const Dom = ({ classes, children }) => {
+const Dom = ({ absolute, classes, children }) => {
   const ref = useRef(null)
   useEffect(() => {
     setState({ dom: ref })
   }, [])
 
-  const className = classes + " absolute top-0 left-0 z-10 w-screen h-full overflow-x-hidden dom"
+  let className = classes + " dom";
+  if (absolute) {
+    className += ' absolute top-0 left-0 z-10 w-screen h-full overflow-x-hidden dom';
+  }
   if (children) {
     console.log(children.props)
   }

--- a/src/components/layout/dom.tsx
+++ b/src/components/layout/dom.tsx
@@ -11,9 +11,7 @@ const Dom = ({ absolute, classes, children }) => {
   if (absolute) {
     className += ' absolute top-0 left-0 z-10 w-screen h-full overflow-x-hidden dom';
   }
-  if (children) {
-    console.log(children.props)
-  }
+
   return (
     <div className={className} ref={ref}>
       {children}

--- a/src/components/layout/dom.tsx
+++ b/src/components/layout/dom.tsx
@@ -1,5 +1,5 @@
 import { setState } from '@/helpers/store'
-import { useEffect, useRef } from 'react'
+import {useEffect, useRef, useState} from 'react'
 
 const Dom = ({ absolute, classes, children }) => {
   const ref = useRef(null)
@@ -7,15 +7,41 @@ const Dom = ({ absolute, classes, children }) => {
     setState({ dom: ref })
   }, [])
 
+  const [showButton, setShowButton] = useState(false);
+
+  useEffect(() => {
+    window.addEventListener("scroll", () => {
+      if (window.scrollY > 300) {
+        setShowButton(true);
+      } else {
+        setShowButton(false);
+      }
+    });
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
+
   let className = classes + " dom";
   if (absolute) {
     className += ' absolute top-0 left-0 z-10 w-screen h-full overflow-x-hidden dom';
   }
 
   return (
-    <div className={className} ref={ref}>
-      {children}
-    </div>
+    <>
+      <div className={className} ref={ref}>
+        {children}
+      </div>
+      {showButton && (
+        <button onClick={scrollToTop} className="fixed right-4 bottom-4 bg-white/25 hover:bg-[#e43a95] text-white/75 hover:text-white text-2xl py-3 px-4 rounded-xl">
+          &#9650;
+        </button>
+      )}
+    </>
   )
 }
 

--- a/src/components/layout/dom.tsx
+++ b/src/components/layout/dom.tsx
@@ -9,9 +9,19 @@ const Dom = ({ absolute, classes, children }) => {
 
   const [showButton, setShowButton] = useState(false);
 
-  useEffect(() => {
+  const scrollOffsetFromBottom = () => {
+    const htmlElement: HTMLElement = document.documentElement;
+    const bodyElement: HTMLElement = document.body;
+
+    return Math.max(
+        htmlElement.clientHeight, htmlElement.scrollHeight, htmlElement.offsetHeight,
+        bodyElement.scrollHeight, bodyElement.offsetHeight
+      ) - (window.scrollY + window.innerHeight);
+  }
+
+  useEffect((): void => {
     window.addEventListener("scroll", () => {
-      if (window.scrollY > 300) {
+      if (window.scrollY > 300 && scrollOffsetFromBottom() > 100) {
         setShowButton(true);
       } else {
         setShowButton(false);
@@ -19,7 +29,7 @@ const Dom = ({ absolute, classes, children }) => {
     });
   }, []);
 
-  const scrollToTop = () => {
+  const scrollToTop = (): void => {
     window.scrollTo({
       top: 0,
       behavior: 'smooth'
@@ -37,7 +47,8 @@ const Dom = ({ absolute, classes, children }) => {
         {children}
       </div>
       {showButton && (
-        <button onClick={scrollToTop} className="fixed right-4 bottom-4 bg-white/25 hover:bg-[#e43a95] text-white/75 hover:text-white text-2xl py-3 px-4 rounded-xl">
+        <button onClick={scrollToTop}
+                className="fixed right-4 bottom-4 bg-white/25 hover:bg-[#e43a95] text-white/75 hover:text-white text-2xl py-3 px-4 rounded-xl">
           &#9650;
         </button>
       )}

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -40,7 +40,7 @@ function App({ Component, pageProps = { title: 'index' } }) {
     <>
       <Header title={title} />
       <Transition>
-        <Dom classes={isColored}>
+        <Dom classes={isColored} absolute={pageProps.title === 'Home'}>
           {Component && <Component {...pageProps} />}
         </Dom>
       </Transition>


### PR DESCRIPTION
Added a "back to top" button when user scrolls the page more than 300px.

I had to remove the absolute positionning on the .dom div for for this to work.
With an absolute div as the main site container, it's impossible to detect the current scrolling position (window.scrollY always returns 0).

Only the homepage uses the absolute position now. No other pages should have any use for it anyway, but it did make CSS more complex.
I didn't find any negative side-effect related to this removal but I could have miss something.

Also removed some debugging code left in dom.tsx.

Resolves #52