### PR TITLE
Fix Twitter cards

### DIFF
--- a/src/config.jsx
+++ b/src/config.jsx
@@ -54,8 +54,11 @@ const Header = ({ title = titleDefault }) => {
       Twitter Summary card
         documentation: https://dev.twitter.com/cards/getting-started
         Be sure validate your Twitter card markup on the documentation site. */}
-        <meta name='twitter:card' content='summary' />
+        <meta name='twitter:card' content='summary_large_image' />
         <meta name='twitter:site' content='@KittyInuToken' />
+        <meta name='twitter:image' content='/img/kitty_logo.jpg' />
+        <meta name='twitter:title' content={title} />
+        <meta name='twitter:description' content={description} />
       </Head>
     </>
   )


### PR DESCRIPTION
URL previews on Twitter don't work correctly. Kitty logo isn't shown. Main reason seems to be the use of "summary" instead of "summary_large_image" for the "twitter:card" meta value.

I've also added some other Twitter meta tags that are theoritically optional according to some sources (Twitter is supposed to used their og:* alternatives when they are missing) but required according to other sources. As a precaution, I've added "twitter:image", "twitter:title" and "twitter:description".